### PR TITLE
fix: categories.user_id is missing

### DIFF
--- a/ciblog.sql
+++ b/ciblog.sql
@@ -28,6 +28,7 @@ SET time_zone = "+00:00";
 
 CREATE TABLE `categories` (
   `id` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL,
   `name` varchar(255) NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
categories.user_id field is missing in DB creation script