### PR TITLE
.htaccess fix

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,4 @@
 RewriteEngine on
-RewriteCond $1 !^(index\.php|assets|images|js|css|uploads|favicon.png)
-RewriteCond %(REQUEST_FILENAME) !-f
-RewriteCond %(REQUEST_FILENAME) !-d
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)$ ./index.php/$1 [L]


### PR DESCRIPTION
```
RewriteCond %(REQUEST_FILENAME) !-f
RewriteCond %(REQUEST_FILENAME) !-d
```
there is a syntax error here, the parentheses are wrong so it won't work.
after fixing it, you won't need this line:
`RewriteCond $1 !^(index\.php|assets|images|js|css|uploads|favicon.png)`
or you can use it alone instead.

the difference between the two that:
in the first method
```
RewriteEngine on
RewriteCond $1 !^(index\.php|assets|images|js|css|uploads|favicon.png)
RewriteRule ^(.*)$ ./index.php/$1 [L] 
```
the only folders (or files) that can be accessed without CodeIgniter are the ones in between the parentheses only,
any other request will route through CodeIgniter.

but in the second method:
```
RewriteEngine on
RewriteCond %{REQUEST_FILENAME} !-f
RewriteCond %{REQUEST_FILENAME} !-d
RewriteRule ^(.*)$ ./index.php/$1 [L]
```
if you put this instead, your request will went through CodeIgniter only if isn't a path to a real file/folder on your system.
for example: if you have a folder name "test" in your project
using the first one (without putting "test" inside the parentheses) will take you to "test" controller.
but if you use the second way, apache will open "test" folder.